### PR TITLE
感想戦: Add descending index `popularity DESC`

### DIFF
--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -29,9 +29,14 @@ CREATE TABLE isuumo.estate
     -- 複数index効かせられないMySQLでは種類ごとの同値(=)検索で引っ掛けるのがORDER BYも効かせられる余地があってよい
     -- ORDER BY popularity DESC, id ASC LIMIT #{per_page} OFFSET #{per_page * page} があるので
     -- INDEX idx_rent_t (rent_t, popularity DESC) にしてORDER BY LIMIT optimizationも狙うべきだった(MySQL 8限定)
-    INDEX idx_rent_t (rent_t),
-    INDEX idx_door_height_t (door_height_t),
-    INDEX idx_door_width_t (door_width_t),
+    --
+    -- INDEX idx_rent_t (rent_t),
+    -- INDEX idx_door_height_t (door_height_t),
+    -- INDEX idx_door_width_t (door_width_t),
+    --
+    INDEX idx_rent_t_popularity (rent_t, popularity DESC),
+    INDEX idx_door_height_t_popularity (door_height_t, popularity DESC),
+    INDEX idx_door_width_t_popularity (door_width_t, popularity DESC),
 
     -- https://github.com/soudai/isucon10-qualify/blob/1be06d2540eb94244596e9a7b541f7c4caf4c14f/webapp/ruby/app.rb#L348
     -- SELECT * FROM estate ORDER BY rent ASC, id ASC LIMIT #{LIMIT}
@@ -72,10 +77,16 @@ CREATE TABLE isuumo.chair
     -- 複数index効かせられないMySQLでは種類ごとの同値(=)検索で引っ掛けるのがORDER BYも効かせられる余地があってよい
     -- ORDER BY popularity DESC, id ASC LIMIT #{per_page} OFFSET #{per_page * page} があるので
     -- INDEX idx_price_t (price_t, popularity DESC) にしてORDER BY LIMIT optimizationも狙うべきだった(MySQL 8限定)
-    INDEX idx_price_t (price_t),
-    INDEX idx_height_t (height_t),
-    INDEX idx_width_t (width_t),
-    INDEX idx_depth_t (depth_t),
+    --
+    -- INDEX idx_price_t (price_t),
+    -- INDEX idx_height_t (height_t),
+    -- INDEX idx_width_t (width_t),
+    -- INDEX idx_depth_t (depth_t),
+    --
+    INDEX idx_price_t_popularity (price_t, popularity DESC),
+    INDEX idx_height_t_popularity (height_t, popularity DESC),
+    INDEX idx_width_t_popularity (width_t, popularity DESC),
+    INDEX idx_depth_t_popularity (depth_t, popularity DESC),
 
     -- https://github.com/soudai/isucon10-qualify/blob/1be06d2540eb94244596e9a7b541f7c4caf4c14f/webapp/ruby/app.rb#L146
     -- SELECT * FROM chair WHERE stock > 0 ORDER BY price ASC, id ASC LIMIT #{LIMIT}
@@ -86,8 +97,12 @@ CREATE TABLE isuumo.chair
     INDEX idx_depth (depth),
 
     -- https://github.com/soudai/isucon10-qualify/blob/1be06d2540eb94244596e9a7b541f7c4caf4c14f/webapp/ruby/app.rb#L175-L183
-    INDEX idx_color (color),
-    INDEX idx_kind (kind),
+    --
+    -- INDEX idx_color (color),
+    -- INDEX idx_kind (kind),
+    --
+    INDEX idx_color_popularity (color, popularity DESC),
+    INDEX idx_kind_popularity (kind, popularity DESC),
 
     -- 常に他の検索条件との複合で必要なので単体では不要
     INDEX idx_popularity (popularity),

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -216,14 +216,13 @@ class App < Sinatra::Base
         halt 400
       end
 
-    sqlprefix = 'SELECT SQL_CALC_FOUND_ROWS * FROM chair WHERE '
+    sqlprefix = 'SELECT * FROM chair WHERE '
     search_condition = search_queries.join(' AND ')
     limit_offset = " ORDER BY popularity DESC, id ASC LIMIT #{per_page} OFFSET #{per_page * page}" # XXX: mysql-cs-bind doesn't support escaping variables for limit and offset
-    #count_prefix = 'SELECT COUNT(*) as count FROM chair WHERE '
+    count_prefix = 'SELECT COUNT(*) as count FROM chair WHERE '
 
-    #count = db.xquery("#{count_prefix}#{search_condition}", query_params).first[:count]
+    count = db.xquery("#{count_prefix}#{search_condition}", query_params).first[:count]
     chairs = db.xquery("#{sqlprefix}#{search_condition}#{limit_offset}", query_params).to_a
-    count = db.query("SELECT FOUND_ROWS() cnt").first[:cnt]
 
     { count: count, chairs: chairs }.to_json
   end
@@ -401,14 +400,13 @@ class App < Sinatra::Base
         halt 400
       end
 
-    sqlprefix = 'SELECT SQL_CALC_FOUND_ROWS * FROM estate WHERE '
+    sqlprefix = 'SELECT * FROM estate WHERE '
     search_condition = search_queries.join(' AND ')
     limit_offset = " ORDER BY popularity DESC, id ASC LIMIT #{per_page} OFFSET #{per_page * page}" # XXX:
-    #count_prefix = 'SELECT COUNT(*) as count FROM estate WHERE '
+    count_prefix = 'SELECT COUNT(*) as count FROM estate WHERE '
 
-    #count = db.xquery("#{count_prefix}#{search_condition}", query_params).first[:count]
+    count = db.xquery("#{count_prefix}#{search_condition}", query_params).first[:count]
     estates = db.xquery("#{sqlprefix}#{search_condition}#{limit_offset}", query_params).to_a
-    count = db.query("SELECT FOUND_ROWS() cnt").first[:cnt]
 
     { count: count, estates: estates.map! { |e| camelize_keys_for_estate(e) } }.to_json
   end


### PR DESCRIPTION
Before:

```
# Time: 2020-09-13T03:37:14.660248Z
# User@Host: root[root] @ localhost []  Id:   520
# Query_time: 0.034722  Lock_time: 0.000161 Rows_sent: 10  Rows_examined: 6888
SET timestamp=1599968234;
SELECT SQL_CALC_FOUND_ROWS * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;

# Time: 2020-09-13T03:37:20.714416Z
# User@Host: root[root] @ localhost []  Id:   520
# Query_time: 0.014294  Lock_time: 0.000213 Rows_sent: 10  Rows_examined: 3454
SET timestamp=1599968240;
SELECT * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;

root@localhost [isuumo] > EXPLAIN SELECT * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;
+----+-------------+--------+------------+------+---------------+------------+---------+-------+------+----------+----------------+
| id | select_type | table  | partitions | type | possible_keys | key        | key_len | ref   | rows | filtered | Extra          |
+----+-------------+--------+------------+------+---------------+------------+---------+-------+------+----------+----------------+
|  1 | SIMPLE      | estate | NULL       | ref  | idx_rent_t    | idx_rent_t | 5       | const | 3444 |   100.00 | Using filesort |
+----+-------------+--------+------------+------+---------------+------------+---------+-------+------+----------+----------------+
1 row in set, 1 warning (0.00 sec)
```

After:

```
# Time: 2020-09-13T03:44:26.615953Z
# User@Host: root[root] @ localhost []  Id:   520
# Query_time: 0.024876  Lock_time: 0.000387 Rows_sent: 10  Rows_examined: 3444
SET timestamp=1599968666;
SELECT SQL_CALC_FOUND_ROWS * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;

# Time: 2020-09-13T03:44:42.873486Z
# User@Host: root[root] @ localhost []  Id:   520
# Query_time: 0.006961  Lock_time: 0.000201 Rows_sent: 10  Rows_examined: 10
SET timestamp=1599968682;
SELECT * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;

root@localhost [isuumo] > EXPLAIN SELECT * FROM estate WHERE rent_t = 0 ORDER BY popularity DESC, id ASC LIMIT 10 OFFSET 0;
+----+-------------+--------+------------+------+-----------------------+-----------------------+---------+-------+------+----------+-------+
| id | select_type | table  | partitions | type | possible_keys         | key                   | key_len | ref   | rows | filtered | Extra |
+----+-------------+--------+------------+------+-----------------------+-----------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | estate | NULL       | ref  | idx_rent_t_popularity | idx_rent_t_popularity | 5       | const | 3444 |   100.00 | NULL  |
+----+-------------+--------+------------+------+-----------------------+-----------------------+---------+-------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)
```

Rows_examined: 3454 -> 10

COUNT(\*)自体は遅くないのでSQL_CALC_FOUND_ROWS狙わずにORDER BY LIMIT optimization狙いでCOUNT(\*)と合わせたほうが速い。

```
# Time: 2020-09-13T03:47:25.704713Z
# User@Host: root[root] @ localhost []  Id:   520
# Query_time: 0.001760  Lock_time: 0.000152 Rows_sent: 1  Rows_examined: 3444
SET timestamp=1599968845;
SELECT COUNT(*) FROM estate WHERE rent_t = 0;
```

いちおうMySQL 5.7でもpopularityを反転させて昇順ソートの揃えれば同じ効率のインデックスにはできる。

```sql
UPDATE estate SET popularity = -popularity
```