### PR TITLE
Avoid N+1 in post '/api/estate/nazotte'

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -436,21 +436,10 @@ class App < Sinatra::Base
 
     coordinates_to_text = "'POLYGON((%s))'" % coordinates.map { |c| '%f %f' % c.values_at(:latitude, :longitude) }.join(',')
 
-    sql = 'SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC'
-    estates = db.xquery(sql, bounding_box[:bottom_right][:latitude], bounding_box[:top_left][:latitude], bounding_box[:bottom_right][:longitude], bounding_box[:top_left][:longitude]).to_a
+    sql = "SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? AND ST_Contains(ST_PolygonFromText(#{coordinates_to_text}), POINT(latitude, longitude)) ORDER BY popularity DESC, id ASC LIMIT #{NAZOTTE_LIMIT}"
 
-    estates_in_polygon = []
-    estates.each do |estate|
-      point = "'POINT(%f %f)'" % estate.values_at(:latitude, :longitude)
-      sql = 'SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s))' % [coordinates_to_text, point]
-      e = db.xquery(sql, estate[:id]).first
-      if e
-        estates_in_polygon << e
-        break if estates_in_polygon.size > NAZOTTE_LIMIT
-      end
-    end
+    nazotte_estates = db.xquery(sql, bounding_box[:bottom_right][:latitude], bounding_box[:top_left][:latitude], bounding_box[:bottom_right][:longitude], bounding_box[:top_left][:longitude]).to_a
 
-    nazotte_estates = estates_in_polygon.take(NAZOTTE_LIMIT)
     {
       estates: nazotte_estates.map! { |e| camelize_keys_for_estate(e) },
       count: nazotte_estates.size,

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -434,13 +434,14 @@ class App < Sinatra::Base
       },
     }
 
+    coordinates_to_text = "'POLYGON((%s))'" % coordinates.map { |c| '%f %f' % c.values_at(:latitude, :longitude) }.join(',')
+
     sql = 'SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC'
     estates = db.xquery(sql, bounding_box[:bottom_right][:latitude], bounding_box[:top_left][:latitude], bounding_box[:bottom_right][:longitude], bounding_box[:top_left][:longitude]).to_a
 
     estates_in_polygon = []
     estates.each do |estate|
       point = "'POINT(%f %f)'" % estate.values_at(:latitude, :longitude)
-      coordinates_to_text = "'POLYGON((%s))'" % coordinates.map { |c| '%f %f' % c.values_at(:latitude, :longitude) }.join(',')
       sql = 'SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s))' % [coordinates_to_text, point]
       e = db.xquery(sql, estate[:id]).first
       if e


### PR DESCRIPTION
ループ内の `ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s))` のN+1を最大50回までに制限してるけど外側のクエリとまとめて一発にできる。
空間インデックスでさらに効率をあげれるかもしれないけどソート順がrecommended_estateと同じなので #16 で足したインデックスで少なくともフルスキャンは割けられる。
逆にいうと予選時は'/api/recommended_estate/:id'と'/api/estate/nazotte'はフルスキャンだから遅かった。